### PR TITLE
Update license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "name": "Lukas Bünger",
     "url": "https://github.com/lukasbuenger"
   },
-  "license": "LicenseRef-LICENSE",
+  "license": "SEE LICENSE IN LICENSE",
   "devDependencies": {
     "babel": "^5.5.8",
     "babel-eslint": "^3.1.15",


### PR DESCRIPTION
Please forgive a tiny PR. This change anticipates impending revision of the npm license metadata guidelines per npm/npm#8609.

Sorry for the back-and-forth on what "magic value" to use to direct users toward a non-standard license file. I hope at least this PR makes the transition easy for you.

All the best from Oakland!